### PR TITLE
Replace .source_file with .path in the .select to eliminate issue with SCSS files

### DIFF
--- a/lib/middleman-inliner.rb
+++ b/lib/middleman-inliner.rb
@@ -13,7 +13,7 @@ class Inliner < Middleman::Extension
     def inline_css(*names)
       names.map { |name|
         name += ".css" unless name.include?(".css")
-        css_path = sitemap.resources.select { |p| p.source_file.include?(name) }.first
+        css_path = sitemap.resources.select { |p| p.path.include?(name) }.first
         "<style type='text/css'>#{css_path.render}</style>"
       }.reduce(:+)
     end


### PR DESCRIPTION
Middleman's `sitemap.resources.source_file` lists the original `.scss` extension for scss files. 

If specify only the file name without extension and I have SCSS or SASS files in the css folder, the `.select` cannot find them.

All `.scss/.sass/.css.erb` files compile to `.css` so it makes sense to use the `.path` attribute which contains the file extensions in their final rendered format.
